### PR TITLE
Fix wrangler.toml: Add proper zone configuration for wildcard SSL routes

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -7,7 +7,20 @@ compatibility_date = "2024-12-01"
 workers_dev = true
 
 # MCP Server requires HTTP routes
-route = { pattern = "*/*", zone_name = "" }
+# IMPORTANT: For routes using wildcard SSL, you must specify either:
+# - zone_name: Your domain name (e.g., "example.com")
+# - zone_id: Your Cloudflare zone ID (found in your domain's dashboard)
+# 
+# Option 1: Using zone_name (recommended for readability)
+# route = { pattern = "*/*", zone_name = "your-domain.com" }
+#
+# Option 2: Using zone_id (more explicit)
+# route = { pattern = "*/*", zone_id = "your-zone-id-here" }
+#
+# For workers_dev = true without custom domain, you can remove the route line entirely
+# Uncomment and configure ONE of the following:
+
+# route = { pattern = "*/*", zone_name = "your-domain.com" }
 
 # Build configuration
 [build]


### PR DESCRIPTION
## Problem
The current `wrangler.toml` configuration has an empty `zone_name = ""` which causes deployment failures when using routes with wildcard SSL. Cloudflare requires either a `zone_name` or `zone_id` to be properly specified for such routes.

## Solution
This PR fixes the issue by:
- Removing the empty `zone_name` configuration
- Adding comprehensive comments explaining how to configure routes with wildcard SSL
- Providing two clear options for users:
  1. Using `zone_name` with their domain (e.g., "example.com")
  2. Using `zone_id` with their Cloudflare zone ID
- Commenting out the route line so users can uncomment and configure it when needed
- Noting that for `workers_dev = true` without a custom domain, the route line can be omitted entirely

## Configuration Options
Users can now choose one of these approaches:

**Option 1: Using zone_name (recommended)**
```toml
route = { pattern = "*/*", zone_name = "your-domain.com" }
```

**Option 2: Using zone_id**
```toml
route = { pattern = "*/*", zone_id = "your-zone-id-here" }
```

**Option 3: Workers.dev only (no custom domain)**
Simply leave the route line commented out when using `workers_dev = true`

## Testing
- [ ] Verify deployment works with a valid zone_name
- [ ] Verify deployment works with a valid zone_id
- [ ] Verify deployment works with workers_dev without route configuration

Fixes the wildcard SSL route deployment error.